### PR TITLE
Add Code: "H35000" (the Previous Question rule was ordered)

### DIFF
--- a/BILLSTATUS-XML_User_User-Guide.md
+++ b/BILLSTATUS-XML_User_User-Guide.md
@@ -473,6 +473,7 @@ The original code set can be found at [http://www.loc.gov/pictures/resource/ppms
 | **H15000** | Held at the desk |
 | **H17000** | Motion to Discharge Committee |
 | **H1L210** | Rule provides for consideration of |
+| **H35000** | The previous question was ordered pursuant to the rule  |
 | **H25200** | Conference report [free text] filed   |
 | **H37300** | Final Passage Under Suspension of the Rules Results |
 | **H38310** | Motion To Reconsider Results |


### PR DESCRIPTION
I found this code in several bills. All pertain to the Previous Question rule having been ordered (shutting down debate, or calling for action, etc).

See bill action "04/17/2018-4:54pm" for this bill:
https://www.congress.gov/bill/115th-congress/house-bill/5192/all-actions